### PR TITLE
Fix Hyperlink Icon

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,9 @@
 serve:
-  hugo serve --baseURL https://hugo.caffeine-pc.local --appendPort=false --liveReloadPort=443 --buildDrafts
+  hugo serve \
+  --baseURL https://hugo.caffeine-pc.local \
+  --appendPort=false \
+  --liveReloadPort=443 \
+  --buildDrafts
 
 submodules:
   git submodule update --init

--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -15,13 +15,4 @@
       border-radius: $radius;
     }
   }
-
-  a {
-    &::after {
-      font-family: 'Font Awesome 6 Free';
-      font-size: 0.75rem;
-      font-variant-position: super;
-      content: " \f08e"
-    }
-  }
 }


### PR DESCRIPTION
On mobile (at least Firefox), the icon next to blog post hyperlinks was being cut off at the top. Instead of removing the superscript position, just remove it.